### PR TITLE
Fix todo list alignment

### DIFF
--- a/todo/todo.py
+++ b/todo/todo.py
@@ -19,10 +19,11 @@ def main(ctx: typer.Context):
         if list:
             print()
             for item in list:
+                space_num = 6 - len(str(item['id']))
                 if item["status"] == "pending":
-                    typer.echo(f"{5*' '}{item['id']} | {KO_SIGN} {item['desc']}")
+                    typer.echo(f"{space_num*' '}{item['id']} | {KO_SIGN} {item['desc']}")
                 else:
-                    typer.echo(f"{5*' '}{item['id']} | {OK_SIGN} {item['desc']}")
+                    typer.echo(f"{space_num*' '}{item['id']} | {OK_SIGN} {item['desc']}")
             print()
         else:
             typer.echo("There are no tasks to show.")


### PR DESCRIPTION
# Fix todo list alignment

This pull request fixes the alignment when there are more than 9 tasks on the todo list.

## Previous output

```
     ...
     8 | ✕ Task8
     9 | ✕ Task9
     10 | ✕ Task10
     11 | ✕ Task11
```

## Current output

```
     ...
     8 | ✕ Task8
     9 | ✕ Task9
    10 | ✕ Task10
    11 | ✕ Task11
```